### PR TITLE
New Functional Features for Pages Hierarchy

### DIFF
--- a/samples/react-pages-hierarchy/package-lock.json
+++ b/samples/react-pages-hierarchy/package-lock.json
@@ -3882,6 +3882,16 @@
         "msal": "1.4.13",
         "msalLegacy": "npm:msal@1.4.12",
         "tslib": "~1.10.0"
+      },
+      "dependencies": {
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@microsoft/sp-listview-extensibility": {
@@ -18732,14 +18742,6 @@
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.13.tgz",
       "integrity": "sha512-uFEa4KGlpGqNMwa7/1OQc6WQUF8iwHbaiHMVn0Cl66Ec7o30ZTtX9s9OWrf0wAxp8Mwg0JEE886z/PHpsiZUxQ==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "msalLegacy": {
-      "version": "npm:msal@1.4.12",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/samples/react-pages-hierarchy/src/webparts/pagehierarchy/PageHierarchyWebPart.ts
+++ b/samples/react-pages-hierarchy/src/webparts/pagehierarchy/PageHierarchyWebPart.ts
@@ -79,10 +79,10 @@ export default class PageHierarchyWebPart extends BaseWebPart<IPageHierarchyWebP
   Really only used for workbench mode when we cannot get a page id for the current page.
   We'll allow user to test with a property and also using mock data allow them to navigate when on local host with a querystring
   */
-  private getDebugPageId() : number {
+  private getDebugPageId(): number {
     let queryParms = new UrlQueryParameterCollection(window.location.href);
     let debugPageId = this.properties.debugPageId;
-    if(queryParms.getValue(Parameters.DEBUGPAGEID)) { debugPageId = Number(queryParms.getValue(Parameters.DEBUGPAGEID)); }
+    if (queryParms.getValue(Parameters.DEBUGPAGEID)) { debugPageId = Number(queryParms.getValue(Parameters.DEBUGPAGEID)); }
 
     return debugPageId;
   }
@@ -162,7 +162,7 @@ export default class PageHierarchyWebPart extends BaseWebPart<IPageHierarchyWebP
           value: this.properties.treeFrom,
           label: strings.PropertyPane_Label_TreeFrom,
           description: strings.PropertyPane_Description_TreeFrom,
-          minValue: 1,
+          minValue: 0,
           disabled: false
         }),
         this.properties.pagesToDisplay === PagesToDisplay.Tree && PropertyFieldNumber('treeExpandTo', {
@@ -170,7 +170,7 @@ export default class PageHierarchyWebPart extends BaseWebPart<IPageHierarchyWebP
           value: this.properties.treeExpandTo,
           label: strings.PropertyPane_Label_TreeExpandTo,
           description: strings.PropertyPane_Description_TreeExpandTo,
-          minValue: 1,
+          minValue: 0,
           disabled: false
         })
       ]

--- a/samples/react-pages-hierarchy/src/webparts/pagehierarchy/loc/en-us.js
+++ b/samples/react-pages-hierarchy/src/webparts/pagehierarchy/loc/en-us.js
@@ -1,4 +1,4 @@
-define([], function() {
+define([], function () {
   return {
     "Configuration_Placeholder_IconText": "Configure Page Hierarchy Web Part",
     "Configuration_Placeholder_Description": "Please configure the web part.",
@@ -22,8 +22,8 @@ define([], function() {
     "PropertyPane_Label_DebugPageId": "Debug Page Id",
     "PropertyPane_Label_VersionInfo": "Version: ",
     "PropertyPane_Description_DebugPageId": "Provide a valid page list item id to see how the web part would render for it",
-    "PropertyPane_Description_TreeFrom": "Please provide the page id for the root of the tree to render",
+    "PropertyPane_Description_TreeFrom": "Please provide the page id for the root of the tree to render. Entering zero will start the tree at the current pages highest ancestor",
     "PropertyPane_Label_TreeExpandTo": "Default Expand the Tree To Level",
-    "PropertyPane_Description_TreeExpandTo": "By default expand the tree to this level"
+    "PropertyPane_Description_TreeExpandTo": "By default expand the tree to this level. Entering zero will inclusively expand the tree along the ancestor path of the current page"
   }
 });


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | No                                |
| New feature?    | Yes                               |
| New sample?     | No                               |

## What's in this Pull Request?

Expanded the tree view to allow the view to:
- Find the current pages highest ancestor when given a page id of zero
- Expand the tree view with only the pages that occur in the ancestor history as well as the current page


